### PR TITLE
Fix numpy versions to 1.23.5 to handle the GPy issue in MOGPR

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         # Workaround for vam.whittaker installation issue https://github.com/WFP-VAM/vam.whittaker/issues/4
-        pip install numpy cython 
+        pip install numpy==1.23.5 cython
         pip install .[dev]
     - name: Lint with flake8
       run: |

--- a/.github/workflows/sphinx2ghpages.yml
+++ b/.github/workflows/sphinx2ghpages.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # Workaround for vam.whittaker installation issue https://github.com/WFP-VAM/vam.whittaker/issues/4
-        python -m pip install numpy cython furo
+        python -m pip install numpy==1.23.5 cython furo
         python -m pip install .[dev]
 
     - name: Sphinx build

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir =
 packages = find:
 python_requires = >= 3.7
 install_requires =
-    numpy>=1.20.0
+    numpy==1.23.5
     GPy>=1.10.0
     vam.whittaker>=2.0.2
     # Workaround for missing GPy dependency (https://github.com/SheffieldML/GPy/issues/980)


### PR DESCRIPTION
We were experiencing issues with the GPy package in the MOGPR functions due to deprecations of some aliases in numpy 1.24.0

```
 `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs
```

This PR fixes the numpy version to a downgraded version, until the issues is addressed in the GPy package