### PR TITLE
Add mogpr timestep option

### DIFF
--- a/src/fusets/mogpr.py
+++ b/src/fusets/mogpr.py
@@ -11,7 +11,6 @@ from typing import List, Union
 import numpy as np
 import pandas as pd
 import xarray
-from xarray import Dataset
 
 from fusets._xarray_utils import _extract_dates, _time_dimension
 from fusets.base import BaseEstimator
@@ -125,7 +124,7 @@ class MOGPRTransformer(BaseEstimator):
         ))
         return out_ds
 
-    def fit_transform(self, X: Union[Dataset, DataCube], y=None, **fit_params):
+    def fit_transform(self, X: Union[xarray.Dataset, DataCube], y=None, **fit_params):
         if _openeo_exists and isinstance(X, DataCube):
             from .openeo import mogpr as mogpr_openeo
             return mogpr_openeo(X)
@@ -133,7 +132,7 @@ class MOGPRTransformer(BaseEstimator):
         return mogpr(X)
 
 
-def mogpr(array: Dataset, variables: List[str] = None, time_dimension="t") -> xarray.Dataset:
+def mogpr(array: xarray.Dataset, variables: List[str] = None, time_dimension="t") -> xarray.Dataset:
     """
     MOGPR (multi-output gaussian-process regression) integrates various timeseries into a single values. This allows to
     fill gaps based on other indicators that are correlated with each other.
@@ -308,7 +307,7 @@ def _MOGPR_GPY_retrieval(data_in, time_in, master_ind, output_timevec, nt):
 def mogpr_1D(data_in, time_in, master_ind, output_timevec, nt, trained_model=None):
     """
     Function performing the multioutput gaussian-process regression at pixel level for gapfilling purposes
-    
+
     Args:
         data_in (list): List of numpy 1D arrays containing data to be processed
         time_in (list): List of numpy 1D arrays containing the (ordinal)dates of each variable in the time dimension
@@ -356,7 +355,7 @@ def mogpr_1D(data_in, time_in, master_ind, output_timevec, nt, trained_model=Non
         Y_vec.append(Y_tmp)
         del X_tmp, Y_tmp
 
-        # Data Normalization        
+        # Data Normalization
         Y_mean_vec.append(np.mean(Y_vec[ind]))
         Y_std_vec.append(np.std(Y_vec[ind]))
         Y_vec[ind] = (Y_vec[ind] - Y_mean_vec[ind]) / Y_std_vec[ind]
@@ -376,7 +375,7 @@ def mogpr_1D(data_in, time_in, master_ind, output_timevec, nt, trained_model=Non
                 # Linear Coregionalization
                 LCM = LCM(input_dim=1, num_outputs=noutputs, kernels_list=[K] * noutputs, W_rank=1)
                 if trained_model is None:
-                    # Linear coregionalization                    
+                    # Linear coregionalization
                     out_model = GPCoregionalizedRegression(Xtrain, Ytrain, kernel=LCM.copy())
                     out_model.optimize()
                 else:
@@ -418,7 +417,7 @@ def mogpr_1D(data_in, time_in, master_ind, output_timevec, nt, trained_model=Non
 
             del Yp, Vp
 
-    # Flatten the series    
+    # Flatten the series
     out_mean_list = []
     out_std_list = []
 

--- a/src/fusets/mogpr.py
+++ b/src/fusets/mogpr.py
@@ -153,9 +153,10 @@ def mogpr(array: xarray.Dataset, variables: List[str] = None, time_dimension: st
     time_dimension = _time_dimension(array, time_dimension)
 
     output_dates = dates
+    output_time_dimension = "t_new"
+    
     if prediction_period is not None:
         output_dates = _output_dates(prediction_period, dates[0], dates[-1])
-        output_time_dimension = "t_new"
 
     dates_np = np.array([d.toordinal() for d in dates], dtype=np.float64)
     output_dates_np = np.array([d.toordinal() for d in output_dates], dtype=np.float64)

--- a/src/fusets/mogpr.py
+++ b/src/fusets/mogpr.py
@@ -154,10 +154,8 @@ def mogpr(array: xarray.Dataset, variables: List[str] = None, time_dimension="t"
 
     dates_np = [d.toordinal() for d in dates]
 
-    if isinstance(array, xarray.Dataset):
-        selected_values = [v.values for v in array.values() if variables is None or v.name in variables]
-    else:
-        selected_values = [array]
+    if variables is not None:
+        array = array.drop_vars([var for var in list(array.data_vars) if var not in variables])
 
     tstep = 5
     time_vec_min = np.min(dates_np)

--- a/src/fusets/mogpr.py
+++ b/src/fusets/mogpr.py
@@ -23,10 +23,10 @@ if _openeo_exists:
 
 class MOGPRTransformer(BaseEstimator):
     """
-    
+
     MOGPR (multi-output gaussia-process regression) integrates various timeseries and delivers the same amount of reconstructed timeseries. This allows to
     fill gaps based on other indicators that are correlated with each other.
-    
+
     """
 
     def __init__(self) -> None:

--- a/src/fusets/mogpr.py
+++ b/src/fusets/mogpr.py
@@ -167,8 +167,8 @@ def mogpr(array: xarray.Dataset, variables: List[str] = None, time_dimension="t"
         raise Exception('The result does not contain any output times, please select a larger range')
 
     def callback(timeseries):
-        out_mean, out_std, out_qflag, out_model = mogpr_1D(timeseries, list([np.array(dates_np) for i in timeseries]),
-                                                           0, output_timevec=output_dates_np, nt=1, trained_model=None)
+        out_mean, _, _, _ = mogpr_1D(timeseries, list([dates_np for _ in timeseries]),
+                                     0, output_timevec=output_dates_np, nt=1, trained_model=None)
         result = np.array(out_mean)
         return result
 

--- a/src/fusets/mogpr.py
+++ b/src/fusets/mogpr.py
@@ -132,7 +132,7 @@ class MOGPRTransformer(BaseEstimator):
         return mogpr(X)
 
 
-def mogpr(array: xarray.Dataset, variables: List[str] = None, time_dimension="t", prediction_period=None) -> xarray.Dataset:
+def mogpr(array: xarray.Dataset, variables: List[str] = None, time_dimension: str="t", prediction_period: str=None) -> xarray.Dataset:
     """
     MOGPR (multi-output gaussian-process regression) integrates various timeseries into a single values. This allows to
     fill gaps based on other indicators that are correlated with each other.

--- a/src/fusets/openeo/mogpr_udf.py
+++ b/src/fusets/openeo/mogpr_udf.py
@@ -54,8 +54,12 @@ def apply_datacube(cube: XarrayDataCube, context: Dict) -> XarrayDataCube:
     home = write_gpy_cfg()
 
     from fusets.mogpr import mogpr
+    variables = context.get('variables')
+    time_dimension = context.get('time_dimension', 't')
+    prediction_period = context.get('prediction_period', '5D')
+
     dims = cube.get_array().dims
-    result = mogpr(cube.get_array().to_dataset(dim="bands"))
+    result = mogpr(cube.get_array().to_dataset(dim="bands"), variables=variables, time_dimension=time_dimension, prediction_period=prediction_period)
     result_dc = XarrayDataCube(result.to_array(dim="bands").transpose(*dims))
     set_home(home)
     return result_dc


### PR DESCRIPTION
Changes:
- added the option for a custom timestep (provided as '5D' or '1M' etc.
- fixed a bug where the provided limited set of variables was not used to limit the data

Closes #96 

(cc. @GriffinBabe I tried this out myself and it works, but it wouldn't hurt if you also give it a try)