### PR TITLE
included notebook links

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -53,3 +53,7 @@ This section contains the API reference, generated from the current state of the
     :members:
     
 ```
+
+## [fusets examples](https://github.com/Open-EO/FuseTS/tree/main/notebooks)
+
+You can delve into practical examples of how to utilize the Fusets library by examining these provided [notebooks](https://github.com/Open-EO/FuseTS/tree/main/notebooks).


### PR DESCRIPTION
Links included under the API section to the notebook examples. Thinking that this would provide more base for the users from within the documentation.